### PR TITLE
Adding @info and @warn for main bayes_opt loop

### DIFF
--- a/docs/src/tutorials/StandardGP_1D.jl
+++ b/docs/src/tutorials/StandardGP_1D.jl
@@ -19,7 +19,7 @@ Random.seed!(42)  # setting the seed for reproducibility of this notebook
 
 # ## Define the objective function
 # We will optimise a simple 1D function: f(x) = (x[1]-2)^2 + sin(3*x[1])
-f(x) = (x[1]-2)^2 + sin(3*x[1])
+f(x) = sum(x.-2)^2 + sin(3*sum(x))
 
 min_f = -0.8494048256167165
 
@@ -64,7 +64,7 @@ print_info(bo_struct)
 
 
 @info "Starting Bayesian Optimization..."
-result, acq_list, standard_params = AbstractBayesOpt.optimize(bo_struct)
+result, acq_list, standard_params = AbstractBayesOpt.optimize(bo_struct,standardize=nothing)
 
 # ## Results
 # The optimization result is stored in `result`. We can print the best found input and its corresponding function value.

--- a/examples/1D_2D_BO_routine/1D_bo_grad.jl
+++ b/examples/1D_2D_BO_routine/1D_bo_grad.jl
@@ -38,9 +38,7 @@ val_grad = f_val_grad.(x_train)
 # Create flattened output
 y_train = [val_grad[i] for i = eachindex(val_grad)]
 
-kernel_constructor = ApproxMatern52Kernel()
-
-kernel = 1 *(kernel_constructor ∘ ScaleTransform(1))
+kernel = ApproxMatern52Kernel()
 model = GradientGP(kernel,d+1,σ²)
 
 # Init of the acquisition function

--- a/examples/1D_2D_BO_routine/2D_bo_grad.jl
+++ b/examples/1D_2D_BO_routine/2D_bo_grad.jl
@@ -12,8 +12,6 @@ using ForwardDiff
 using LaTeXStrings
 using AbstractBayesOpt
 
-using BenchmarkTools
-
 import Random
 Random.seed!(123456)
 
@@ -49,11 +47,8 @@ y_train = [val_grad[i] for i = eachindex(val_grad)]
 
 
 
-kernel_constructor = ApproxMatern52Kernel()
-kernel = 1 * (kernel_constructor ∘ ScaleTransform(1))
-grad_kernel = gradKernel(kernel)
-
-model = GradientGP(grad_kernel,d+1,σ²)
+kernel = ApproxMatern52Kernel()
+model = GradientGP(kernel,d+1,σ²)
 
 # Init of the acquisition function
 ξ = 0.0

--- a/examples/1D_2D_BO_routine/2D_bo_nograd.jl
+++ b/examples/1D_2D_BO_routine/2D_bo_nograd.jl
@@ -45,7 +45,7 @@ upper = [6.0,6.0]
 domain = ContinuousDomain(lower, upper)
 σ² = 1e-12
 
-kernel_constructor = ApproxMatern52Kernel()
+kernel = ApproxMatern52Kernel()
 
 # Generate uniform random samples
 n_train = 10
@@ -54,7 +54,6 @@ y_train = f.(x_train) #+ sqrt(σ²).* randn(n_train)
 
 y_train = map(x -> [x], y_train)
 
-kernel = 1 *(kernel_constructor ∘ ScaleTransform(1))
 model = StandardGP(kernel,σ²) # Instantiates the StandardGP (gives it the prior).
 
 # Conditioning: no need if true


### PR DESCRIPTION
This PR replaces all println statements with proper logging macros.

- `@info` used for normal program flow messages
- `@debug` used for developer/debugging messages
- No functional changes, just better log management

Closes #12 