### PR TITLE
fix: workaround for issue 55. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractBayesOpt"
 uuid = "735adf16-6ca3-4095-a89a-9a0ece110843"
+version = "0.1.4"
 authors = ["Eliott Van Dieren"]
-version = "0.1.3"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/surrogates/GradientGP.jl
+++ b/src/surrogates/GradientGP.jl
@@ -175,9 +175,9 @@ returns:
 """
 function kappa_matern52(v::Real)
     d = sqrt(v)
-    z = exp(-sqrt(5)*d)
-    φ_val = (1 + sqrt(5)*d + 5d^2/3) * z
-    φ_deriv = (-5/6)*(1 + sqrt(5)*d)*z
+    z = exp(-sqrt(5) * d)
+    φ_val = (1 + sqrt(5) * d + 5d^2 / 3) * z
+    φ_deriv = (-5 / 6) * (1 + sqrt(5) * d) * z
     return φ_val, φ_deriv
 end
 
@@ -199,13 +199,24 @@ function kappa_matern52(v::ForwardDiff.Dual{T}) where {T}
     w = ForwardDiff.value(v)
     parts = ForwardDiff.partials(v)
 
+    if w isa ForwardDiff.Dual
+        @warn "ADMatern52Kernel: computing 3rd-order derivatives of the Matérn 5/2 kernel, " *
+            "which is only twice differentiable. These results are only valid for " *
+            "hyperparameter tuning and should not be used for other purposes." maxlog = 1
+    end
+
     φ_val, φ_deriv = kappa_matern52(w)
 
-    d = sqrt(w)
-    φ_dd = 25/12*exp(-sqrt(5)*d)
+    # When w is itself a Dual (triple-nested AD: K_dd block + hyperparameter gradient),
+    # sqrt(w) at value(w)==0 yields NaN partials via IEEE 0/0. The true derivative
+    # d(sqrt(w))/dℓ² vanishes at w=0 because d²=||x-y||²/ℓ²=0
+    # See Warning above. 
+    w_val = ForwardDiff.value(w)
+    d = iszero(w_val) ? zero(w) : sqrt(w)
+    φ_dd = 25 / 12 * exp(-sqrt(5) * d)
 
-    return ForwardDiff.Dual{T}(φ_val, φ_deriv*parts),
-    ForwardDiff.Dual{T}(φ_deriv, φ_dd*parts)
+    return ForwardDiff.Dual{T}(φ_val, φ_deriv * parts),
+    ForwardDiff.Dual{T}(φ_deriv, φ_dd * parts)
 end
 
 """
@@ -245,7 +256,7 @@ function KernelFunctions.kappa(::ADMatern52Kernel, d²::ForwardDiff.Dual{T}) whe
 
     φ_val, φ_deriv = kappa_matern52(v)
 
-    return ForwardDiff.Dual{T}(φ_val, φ_deriv*parts)
+    return ForwardDiff.Dual{T}(φ_val, φ_deriv * parts)
 end
 
 """
@@ -322,7 +333,7 @@ function KernelFunctions.kappa(k::ApproxMatern72Kernel, d²::Real)
         return 1.0 - (7.0 / 10) * d²
     else
         d = sqrt(d²)
-        return (1 + sqrt(7) * d + 14/5 * d² + 7*sqrt(7)/15*d^3) * exp(-sqrt(7) * d)
+        return (1 + sqrt(7) * d + 14 / 5 * d² + 7 * sqrt(7) / 15 * d^3) * exp(-sqrt(7) * d)
     end
 end
 
@@ -399,10 +410,10 @@ returns:
 """
 function kappa_matern72(v::Real)
     d = sqrt(v)
-    z = exp(-sqrt(7)*d)
-    φ_val = (1 + sqrt(7)*d + 14*d^2/5 + 7*sqrt(7)*d^3/15) * z
-    φ_deriv = -7/10 * (1 + sqrt(7)*d + 7*d^2/3) * z
-    φ_dd = (49/60)*(1 + sqrt(7)*d)*z
+    z = exp(-sqrt(7) * d)
+    φ_val = (1 + sqrt(7) * d + 14 * d^2 / 5 + 7 * sqrt(7) * d^3 / 15) * z
+    φ_deriv = -7 / 10 * (1 + sqrt(7) * d + 7 * d^2 / 3) * z
+    φ_dd = (49 / 60) * (1 + sqrt(7) * d) * z
     return φ_val, φ_deriv, φ_dd
 end
 
@@ -429,11 +440,11 @@ function kappa_matern72(v::ForwardDiff.Dual{T}) where {T}
     φ_val, φ_deriv, φ_dd = kappa_matern72(w)
 
     d = sqrt(w)
-    φ_ddd = -7*49/120*exp(-sqrt(7)*d)
+    φ_ddd = -7 * 49 / 120 * exp(-sqrt(7) * d)
 
-    return ForwardDiff.Dual{T}(φ_val, φ_deriv*parts),
-    ForwardDiff.Dual{T}(φ_deriv, φ_dd*parts),
-    ForwardDiff.Dual{T}(φ_dd, φ_ddd*parts)
+    return ForwardDiff.Dual{T}(φ_val, φ_deriv * parts),
+    ForwardDiff.Dual{T}(φ_deriv, φ_dd * parts),
+    ForwardDiff.Dual{T}(φ_dd, φ_ddd * parts)
 end
 
 """
@@ -470,7 +481,7 @@ function KernelFunctions.kappa(::ADMatern72Kernel, d²::ForwardDiff.Dual{T}) whe
     v = ForwardDiff.value(d²)
     parts = ForwardDiff.partials(d²)
     φ_val, φ_deriv, _ = kappa_matern72(v)
-    return ForwardDiff.Dual{T}(φ_val, φ_deriv*parts)
+    return ForwardDiff.Dual{T}(φ_val, φ_deriv * parts)
 end
 
 """
@@ -573,8 +584,6 @@ Some snippets kindly provided by [N. Schmitz](https://github.com/niklasschmitz),
 function (κ::gradKernel)((x, px)::Tuple{X,Int}, (y, py)::Tuple{Y,Int}) where {X,Y}
     (px > length(x) + 1 || py > length(y) + 1 || px < 1 || py < 1) &&
         error("`px` and `py` must be within the range of the number of outputs")
-
-    onehot(n, i) = 1:n .== i # collect(1:n) .== i
 
     val = px == 1 && py == 1 # we are looking at f(x), f(y)
 
@@ -935,7 +944,7 @@ returns:
 """
 function posterior_grad_mean(model::GradientGP, x)
     # Be careful with the output order, it is (f(x1),f(x2),...,∂₁f(x1),∂₁f(x2),...)
-    mean(model.gpx(_prep_input(x, model.p)))
+    return mean(model.gpx(_prep_input(x, model.p)))
 end
 
 """
@@ -951,7 +960,7 @@ returns:
 - `var::Vector`: The variance predictions
 """
 function posterior_grad_var(model::GradientGP, x)
-    var(model.gpx(_prep_input(x, model.p)))
+    return var(model.gpx(_prep_input(x, model.p)))
 end
 
 """
@@ -967,7 +976,7 @@ returns:
 - `cov::Matrix`: The covariance matrix of the predictions
 """
 function posterior_grad_cov(model::GradientGP, x)
-    cov(model.gpx(_prep_input(x, model.p)))
+    return cov(model.gpx(_prep_input(x, model.p)))
 end
 
 """
@@ -983,7 +992,7 @@ returns:
 - `mean::Vector`: The mean predictions (function value only)
 """
 function posterior_mean(model::GradientGP, x)
-    mean(model.gpx(_prep_input(x, 1)))
+    return mean(model.gpx(_prep_input(x, 1)))
 end
 
 """
@@ -999,7 +1008,7 @@ returns:
 - `var::Vector`: The variance predictions (function value only)
 """
 function posterior_var(model::GradientGP, x)
-    var(model.gpx(_prep_input(x, 1)))
+    return var(model.gpx(_prep_input(x, 1)))
 end
 
 """

--- a/test/test_kernels.jl
+++ b/test/test_kernels.jl
@@ -13,15 +13,15 @@ Random.seed!(1234)
     d = 2
     ℓ = 2.0
     σ² = 4.0
-    reference_kernel = σ²*with_lengthscale(Matern52Kernel(), ℓ)
-    GP_ref = GradientGP(reference_kernel, d+1, 0)
+    reference_kernel = σ² * with_lengthscale(Matern52Kernel(), ℓ)
+    GP_ref = GradientGP(reference_kernel, d + 1, 0)
 
     # Hyperparameter testing for construction
-    approx_kernel = σ²*with_lengthscale(ApproxMatern52Kernel(), ℓ)
-    GP_approx = GradientGP(approx_kernel, d+1, 0)
+    approx_kernel = σ² * with_lengthscale(ApproxMatern52Kernel(), ℓ)
+    GP_approx = GradientGP(approx_kernel, d + 1, 0)
 
-    ad_kernel = σ²*with_lengthscale(ADMatern52Kernel(), ℓ)
-    GP_ad = GradientGP(ad_kernel, d+1, 0)
+    ad_kernel = σ² * with_lengthscale(ADMatern52Kernel(), ℓ)
+    GP_ad = GradientGP(ad_kernel, d + 1, 0)
 
     @test AbstractBayesOpt.get_lengthscale(GP_ref)[1] ==
         AbstractBayesOpt.get_lengthscale(GP_approx)[1] ==
@@ -43,7 +43,7 @@ Random.seed!(1234)
         @test isapprox(ad_kernel(x1, x2), reference_kernel(x1, x2); atol=1e-12)
 
         ### check hyperparameter scaling
-        ref_val = σ²*KernelFunctions.kappa(Matern52Kernel(), norm(x1 - x2)/ℓ)
+        ref_val = σ² * KernelFunctions.kappa(Matern52Kernel(), norm(x1 - x2) / ℓ)
         @test isapprox(approx_kernel(x1, x2), ref_val; atol=1e-12)
         @test isapprox(ad_kernel(x1, x2), ref_val; atol=1e-12)
 
@@ -51,7 +51,7 @@ Random.seed!(1234)
         @test isapprox(approx_kernel(x1, x1), reference_kernel(x1, x1); atol=1e-12)
         @test isapprox(ad_kernel(x1, x1), reference_kernel(x1, x1); atol=1e-12)
 
-        ref_val = σ²*KernelFunctions.kappa(Matern52Kernel(), 0.0)
+        ref_val = σ² * KernelFunctions.kappa(Matern52Kernel(), 0.0)
         @test isapprox(approx_kernel(x1, x1), ref_val; atol=1e-12)
         @test isapprox(ad_kernel(x1, x1), ref_val; atol=1e-12)
 
@@ -69,9 +69,11 @@ Random.seed!(1234)
 
         ## hyperparameter tests (over second variable to match above)
         ∇k_ref_val(x, y) =
-            σ²*ForwardDiff.derivative(
-                z -> KernelFunctions.kappa(Matern52Kernel(), z/ℓ), norm(x-y)
-            )*(y-x)/norm(x-y)
+            σ² *
+            ForwardDiff.derivative(
+                z -> KernelFunctions.kappa(Matern52Kernel(), z / ℓ), norm(x - y)
+            ) *
+            (y - x) / norm(x - y)
         ref_val = ∇k_ref_val(x1, x2)
 
         @test isapprox(∇k_ref(x1, x2), ref_val; atol=1e-12)
@@ -90,7 +92,7 @@ Random.seed!(1234)
     @testset "Posteriors" begin
 
         # Check posterior mean value and derivatives
-        f(x) = sin(π*x[1])*cos(π*x[2])
+        f(x) = sin(π * x[1]) * cos(π * x[2])
         ∇f(x) = ForwardDiff.gradient(f, x)
         f_val_grad(x) = [f(x); ∇f(x)]
         y_∂y = [f_val_grad(x) for x in X]
@@ -115,11 +117,13 @@ Random.seed!(1234)
         x_train = X[1]
         @test isapprox(post_mean_approx(x_train), post_mean_ad(x_train); atol=1e-12)
         @test isapprox(∇post_mean_approx(x_train), ∇post_mean_ad(x_train); atol=1e-10)
-        @test !isapprox(
+        # After the fix for issue #55, ADMatern52Kernel no longer produces NaN for the
+        # Hessian at training points. Matern 5/2 is C², so its cross-Hessian k_xy is
+        # finite at x==y; the NaN was an artifact of sqrt(Dual(0)) in the AD rules.
+        @test all(isfinite.(hessian_post_mean_ad(x_train)))
+        @test isapprox(
             hessian_post_mean_approx(x_train), hessian_post_mean_ad(x_train); atol=1e-8
         )
-        @test all(isnan.(hessian_post_mean_ad(x_train))) # this produces NaNs, as expected
-        # One should not believe in the Hessian at a training point, for the Matern 5/2 kernel!
 
         # posterior gradient mean
         post_grad_mean_approx(x) = posterior_grad_mean(post_approx, [x])
@@ -157,6 +161,36 @@ Random.seed!(1234)
         @test isapprox(post_grad_var_approx(x_train), post_grad_var_ad(x_train); atol=1e-10)
     end # of posteriors tests
 
+    @testset "NLML ForwardDiff gradient (regression test for issue #55)" begin
+        # Regression test: ForwardDiff.gradient through nlml on a GradientGP with
+        # ADMatern52Kernel must not produce NaN. The K_dd block (double spatial
+        # derivative) creates triple-nested Duals; sqrt(Dual(0,0)) used to yield NaN.
+        f(x) = sin(π * x[1]) * cos(π * x[2])
+        ∇f(x) = ForwardDiff.gradient(f, x)
+        f_val_grad(x) = [f(x); ∇f(x)]
+        y_∂y = [f_val_grad(x) for x in X]
+
+        X_mo = AbstractBayesOpt.prep_input(GP_ad, X)
+        y_mo = AbstractBayesOpt.prep_output(GP_ad, y_∂y)
+        params0 = log.([ℓ, σ²])
+
+        grad_approx = ForwardDiff.gradient(
+            p -> AbstractBayesOpt.nlml(
+                GP_approx,
+                p,
+                AbstractBayesOpt.prep_input(GP_approx, X),
+                AbstractBayesOpt.prep_output(GP_approx, y_∂y),
+            ),
+            params0,
+        )
+        grad_ad = ForwardDiff.gradient(
+            p -> AbstractBayesOpt.nlml(GP_ad, p, X_mo, y_mo), params0
+        )
+
+        @test all(isfinite.(grad_ad))  # must not contain NaN (regression for issue #55)
+        @test isapprox(grad_approx, grad_ad; atol=1e-6)
+    end # of NLML ForwardDiff gradient tests
+
     @testset "Printing tests" begin
         io = IOBuffer()
 
@@ -178,15 +212,15 @@ end # of Matern 5/2 tests
     d = 2
     ℓ = 2.0
     σ² = 4.0
-    reference_kernel = σ²*with_lengthscale(Matern72Kernel(), ℓ)
-    GP_ref = GradientGP(reference_kernel, d+1, 0)
+    reference_kernel = σ² * with_lengthscale(Matern72Kernel(), ℓ)
+    GP_ref = GradientGP(reference_kernel, d + 1, 0)
 
     # Hyperparameter testing for construction
-    approx_kernel = σ²*with_lengthscale(ApproxMatern72Kernel(), ℓ)
-    GP_approx = GradientGP(approx_kernel, d+1, 0)
+    approx_kernel = σ² * with_lengthscale(ApproxMatern72Kernel(), ℓ)
+    GP_approx = GradientGP(approx_kernel, d + 1, 0)
 
-    ad_kernel = σ²*with_lengthscale(ADMatern72Kernel(), ℓ)
-    GP_ad = GradientGP(ad_kernel, d+1, 0)
+    ad_kernel = σ² * with_lengthscale(ADMatern72Kernel(), ℓ)
+    GP_ad = GradientGP(ad_kernel, d + 1, 0)
 
     @test AbstractBayesOpt.get_lengthscale(GP_ref)[1] ==
         AbstractBayesOpt.get_lengthscale(GP_approx)[1] ==
@@ -209,7 +243,7 @@ end # of Matern 5/2 tests
         @test isapprox(ad_kernel(x1, x2), reference_kernel(x1, x2); atol=1e-12)
 
         ### check hyperparameter scaling
-        ref_val = σ²*KernelFunctions.kappa(Matern72Kernel(), norm(x1 - x2)/ℓ)
+        ref_val = σ² * KernelFunctions.kappa(Matern72Kernel(), norm(x1 - x2) / ℓ)
         @test isapprox(approx_kernel(x1, x2), ref_val; atol=1e-12)
         @test isapprox(ad_kernel(x1, x2), ref_val; atol=1e-12)
 
@@ -217,7 +251,7 @@ end # of Matern 5/2 tests
         @test isapprox(approx_kernel(x1, x1), reference_kernel(x1, x1); atol=1e-12)
         @test isapprox(ad_kernel(x1, x1), reference_kernel(x1, x1); atol=1e-12)
 
-        ref_val = σ²*KernelFunctions.kappa(Matern72Kernel(), 0.0)
+        ref_val = σ² * KernelFunctions.kappa(Matern72Kernel(), 0.0)
         @test isapprox(approx_kernel(x1, x1), ref_val; atol=1e-12)
         @test isapprox(ad_kernel(x1, x1), ref_val; atol=1e-12)
 
@@ -235,9 +269,11 @@ end # of Matern 5/2 tests
 
         ## hyperparameter tests (over second variable to match above)
         ∇k_ref_val(x, y) =
-            σ²*ForwardDiff.derivative(
-                z -> KernelFunctions.kappa(Matern72Kernel(), z/ℓ), norm(x-y)
-            )*(y-x)/norm(x-y)
+            σ² *
+            ForwardDiff.derivative(
+                z -> KernelFunctions.kappa(Matern72Kernel(), z / ℓ), norm(x - y)
+            ) *
+            (y - x) / norm(x - y)
         ref_val = ∇k_ref_val(x1, x2)
 
         @test isapprox(∇k_ref(x1, x2), ref_val; atol=1e-12)
@@ -256,7 +292,7 @@ end # of Matern 5/2 tests
     @testset "Posteriors tests" begin
 
         # Check posterior mean derivatives
-        f(x) = sin(π*x[1])*cos(π*x[2])
+        f(x) = sin(π * x[1]) * cos(π * x[2])
         ∇f(x) = ForwardDiff.gradient(f, x)
         f_val_grad(x) = [f(x); ∇f(x)]
         y_∂y = [f_val_grad(x) for x in X]


### PR DESCRIPTION
The ADMatern52 kernel cannot be differentiated 3 times (necessary for hyperparameter optimisation), so a default of 0 is set and a warning thrown when this is done. The ForwarDiff differentiation of the ADMatern52 kernel is therefore INCORRECT after deriving 3+ times (note that the kernel is only 2-differentiable in general).