### PR TITLE
Adding GPs with linear observations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractBayesOpt"
 uuid = "735adf16-6ca3-4095-a89a-9a0ece110843"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Eliott Van Dieren"]
 
 [deps]

--- a/src/AbstractBayesOpt.jl
+++ b/src/AbstractBayesOpt.jl
@@ -18,10 +18,10 @@ include("abstract.jl")
 export AbstractAcquisition, AbstractSurrogate, AbstractDomain
 
 # Surrogate models
+include("surrogates/surrogates_utils.jl")
 include("surrogates/StandardGP.jl")
 include("surrogates/GradientGP.jl")
 include("surrogates/LinearOperatorGP.jl")
-include("surrogates/surrogates_utils.jl")
 
 ## Models
 export StandardGP, GradientGP, LinearOperatorGP

--- a/src/AbstractBayesOpt.jl
+++ b/src/AbstractBayesOpt.jl
@@ -20,10 +20,14 @@ export AbstractAcquisition, AbstractSurrogate, AbstractDomain
 # Surrogate models
 include("surrogates/StandardGP.jl")
 include("surrogates/GradientGP.jl")
+include("surrogates/LinearOperatorGP.jl")
 include("surrogates/surrogates_utils.jl")
 
 ## Models
-export StandardGP, GradientGP
+export StandardGP, GradientGP, LinearOperatorGP
+
+## Operators for LinearOperatorGP
+export IdentityOperator, PartialDerivative, LaplacianOperator
 
 ## Methods
 export posterior_mean, posterior_var, nlml
@@ -34,6 +38,9 @@ export ApproxMatern52Kernel, ADMatern52Kernel, ApproxMatern72Kernel, ADMatern72K
 
 ## Gradient kernel and mean functions
 export gradConstMean, gradKernel
+
+## LinearOperatorMean and LinearOperatorKernel structs
+export LinearOperatorMean, LinearOperatorKernel
 
 ## Surrogate utils
 export prep_input, unstandardized_mean_and_var

--- a/src/surrogates/GradientGP.jl
+++ b/src/surrogates/GradientGP.jl
@@ -897,22 +897,6 @@ returns:
 """
 prep_input(model::GradientGP, xs) = _prep_input(xs, model.p)
 
-function _prep_input(x::AbstractVector{X}, p::Int) where {X}
-    return KernelFunctions.MOInputIsotopicByOutputs(x, p)
-end
-
-function _prep_input(x::AbstractVector{<:Tuple{X,Int}}, p::Int) where {X}
-    return x
-end
-
-function _prep_input(x::Tuple{X,Int}, p::Int) where {X}
-    return [x]
-end
-
-function _prep_input(x::X, p::Int) where {X<:Real}
-    return _prep_input([x], p)
-end
-
 """
     prep_output(model::GradientGP, y::Vector{Y}) where {Y}
 

--- a/src/surrogates/LinearOperatorGP.jl
+++ b/src/surrogates/LinearOperatorGP.jl
@@ -49,18 +49,22 @@ returns:
 (::IdentityOperator)(f, x) = f(x)
 
 """
-    _unitvec(x, i)
+    _unitvec(x::AbstractVector, i::Int)
 
 Construct a unit vector of the same type and length as `x` with a one in position `i`.
 
 Arguments:
-- `x`: A vector used to determine the length and element type.
+- `x::AbstractVector`: A vector used to determine the length and element type.
 - `i::Int`: The index of the non-zero entry.
 
 returns:
 - `e::Vector`: A unit vector with `e[i] = 1` and zeros elsewhere.
 """
-function _unitvec(x, i)
+function _unitvec(x::AbstractVector, i::Int)
+    1 <= i <= length(x) || throw(ArgumentError(
+        "index i=$i must satisfy 1 <= i <= length(x)=$(length(x))"
+    ))
+    
     e = zeros(eltype(x), length(x))
     e[i] = one(eltype(x))
     return e

--- a/src/surrogates/LinearOperatorGP.jl
+++ b/src/surrogates/LinearOperatorGP.jl
@@ -1,0 +1,666 @@
+"""
+    abstract type AbstractLinearOperator
+
+Abstract type for linear operators applied to a latent GP.
+All concrete operators must implement the callable interface `(op::MyOperator)(f, x)`
+which applies the operator to a scalar-valued function `f` at point `x`.
+"""
+abstract type AbstractLinearOperator end
+
+"""
+    struct IdentityOperator <: AbstractLinearOperator
+
+Linear operator that returns the function value unchanged, i.e. `(If)(x) = f(x)`.
+"""
+struct IdentityOperator <: AbstractLinearOperator end
+
+"""
+    struct PartialDerivative <: AbstractLinearOperator
+
+Linear operator that computes the partial derivative of a function with respect to
+dimension `dim`, i.e. `(∂_i f)(x) = ∂f/∂x_i`.
+
+Attributes:
+- `dim::Int`: The dimension along which to differentiate.
+"""
+struct PartialDerivative <: AbstractLinearOperator
+    dim::Int
+end
+
+"""
+    struct LaplacianOperator <: AbstractLinearOperator
+
+Linear operator that computes the Laplacian of a function, i.e. `(Δf)(x) = Σᵢ ∂²f/∂xᵢ²`.
+"""
+struct LaplacianOperator <: AbstractLinearOperator end
+
+"""
+    (::IdentityOperator)(f, x)
+
+Apply the identity operator to `f` at `x`, returning `f(x)` unchanged.
+
+Arguments:
+- `f`: A scalar-valued function.
+- `x`: The input point.
+
+returns:
+- `f(x)`: The function value at `x`.
+"""
+(::IdentityOperator)(f, x) = f(x)
+
+"""
+    _unitvec(x, i)
+
+Construct a unit vector of the same type and length as `x` with a one in position `i`.
+
+Arguments:
+- `x`: A vector used to determine the length and element type.
+- `i::Int`: The index of the non-zero entry.
+
+returns:
+- `e::Vector`: A unit vector with `e[i] = 1` and zeros elsewhere.
+"""
+function _unitvec(x, i)
+    e = zeros(eltype(x), length(x))
+    e[i] = one(eltype(x))
+    return e
+end
+
+"""
+    (op::PartialDerivative)(f, x)
+
+Apply the partial derivative operator to `f` at `x` along dimension `op.dim`,
+computed via forward-mode automatic differentiation.
+
+Arguments:
+- `op::PartialDerivative`: The operator, carrying the dimension `op.dim`.
+- `f`: A scalar-valued function.
+- `x`: The input point.
+
+returns:
+- `∂f/∂x_i`: The partial derivative of `f` at `x` along dimension `op.dim`.
+"""
+function (op::PartialDerivative)(f, x)
+    e = _unitvec(x, op.dim)
+    return ForwardDiff.derivative(h -> f(x .+ h .* e), zero(eltype(x)))
+end
+
+"""
+    (::LaplacianOperator)(f, x)
+
+Apply the Laplacian operator to `f` at `x`, computed as the trace of the Hessian
+via forward-mode automatic differentiation.
+
+Arguments:
+- `f`: A scalar-valued function.
+- `x`: The input point.
+
+returns:
+- `Δf(x)`: The Laplacian of `f` at `x`, i.e. `Σᵢ ∂²f/∂xᵢ²`.
+"""
+function (::LaplacianOperator)(f, x)
+    return LinearAlgebra.tr(ForwardDiff.hessian(f, x))
+end
+
+"""
+    struct LinearOperatorKernel{K, Ops} <: KernelFunctions.Kernel
+
+Kernel for a GP observed through linear operators. For operators `Lᵢ` and `Lⱼ`,
+the kernel between two tagged inputs `(x, i)` and `(y, j)` is defined as:
+
+    k_ij(x, y) = Lᵢˣ Lⱼʸ k(x, y)
+
+where `Lᵢˣ` denotes operator `i` applied in the `x` argument.
+
+Attributes:
+- `base_kernel::K`: The kernel of the latent GP.
+- `ops::Ops`: The collection of linear operators.
+"""
+struct LinearOperatorKernel{K,Ops} <: KernelFunctions.Kernel
+    base_kernel::K
+    ops::Ops
+end
+
+"""
+    struct LinearOperatorMean{M, Ops} <: AbstractGPs.MeanFunction
+
+Mean function for a GP observed through linear operators. For operator `Lᵢ`,
+the mean at tagged input `(x, i)` is defined as:
+
+    m_i(x) = Lᵢ m(x)
+
+where `m` is the base mean function of the latent GP.
+
+Attributes:
+- `base_mean::M`: The mean function of the latent GP.
+- `ops::Ops`: The collection of linear operators.
+"""
+struct LinearOperatorMean{M,Ops} <: AbstractGPs.MeanFunction
+    base_mean::M
+    ops::Ops
+end
+
+"""
+    AbstractGPs.mean_vector(m::LinearOperatorMean, xs)
+
+Evaluate the linear operator mean function at a vector of tagged inputs.
+
+Arguments:
+- `m::LinearOperatorMean`: The mean function.
+- `xs`: A vector of tagged inputs of the form `(x, i)`.
+
+returns:
+- `Vector`: The mean vector, where each entry is `Lᵢ m(x)` for the corresponding `(x, i)`.
+"""
+function AbstractGPs.mean_vector(m::LinearOperatorMean, xs)
+    return [m.ops[i](z -> _scalar_mean(m.base_mean, z), x) for (x, i) in xs]
+end
+
+"""
+    _scalar_mean(m, x)
+
+Evaluate a mean function `m` at a single point `x`, returning a scalar.
+
+Arguments:
+- `m`: A `MeanFunction` compatible with `AbstractGPs.mean_vector`.
+- `x`: A single input point.
+
+returns:
+- `Float64`: The scalar mean value at `x`.
+"""
+_scalar_mean(m, x) = only(AbstractGPs.mean_vector(m, [x]))
+
+"""
+    make_linear_operator_mean(base_mean, ops)
+
+Construct a `CustomMean` that applies the appropriate linear operator to the base mean
+function based on the output index of each tagged input.
+
+Arguments:
+- `base_mean`: The mean function of the latent GP.
+- `ops`: The collection of linear operators.
+
+returns:
+- `AbstractGPs.CustomMean`: A mean function that evaluates `Lᵢ m(x)` for tagged input `(x, i)`.
+"""
+function make_linear_operator_mean(base_mean, ops)
+    return AbstractGPs.CustomMean() do xi
+        x, i = xi
+        return ops[i](z -> _scalar_mean(base_mean, z), x)
+    end
+end
+
+"""
+    (κ::LinearOperatorKernel)((x, i), (y, j))
+
+Evaluate the linear operator kernel at two tagged inputs `(x, i)` and `(y, j)`.
+Applies operator `i` in the `x` argument and operator `j` in the `y` argument
+to the base kernel:
+
+    k_ij(x, y) = Lᵢˣ Lⱼʸ k(x, y)
+
+Arguments:
+- `κ::LinearOperatorKernel`: The kernel instance.
+- `(x, i)`: A tagged input, where `i` is the operator index.
+- `(y, j)`: A tagged input, where `j` is the operator index.
+
+returns:
+- `Float64`: The kernel value `Lᵢˣ Lⱼʸ k(x, y)`.
+"""
+function (κ::LinearOperatorKernel)((x, i), (y, j))
+    opx = κ.ops[i]
+    opy = κ.ops[j]
+    return opx(a -> opy(b -> κ.base_kernel(a, b), y), x)
+end
+
+"""
+    struct LinearOperatorGP{G, T, Ops} <: AbstractSurrogate
+
+Gaussian Process surrogate model for observations of linear functionals of a latent GP.
+
+Attributes:
+- `gp::G`: The underlying Gaussian Process model.
+- `noise_var::T`: The noise variance of the observations. Can be a `Real` (uniform noise),
+    a `Tuple` of length p (one variance per operator type), or an `AbstractVector` of
+    length n (one variance per observation, fully heteroskedastic).
+- `ops::Ops`: The collection of linear operators applied to the latent GP.
+- `p::Int`: The number of operators (output types).
+- `gpx::Union{Nothing, AbstractGPs.PosteriorGP}`: The posterior GP after conditioning on
+    data, `nothing` if not yet conditioned.
+"""
+struct LinearOperatorGP{G,T,Ops} <: AbstractSurrogate
+    gp::G
+    noise_var::T
+    ops::Ops
+    p::Int
+    gpx::Union{Nothing,AbstractGPs.PosteriorGP}
+end
+
+"""
+    LinearOperatorGP(base_kernel, ops, noise_var; mean=AbstractGPs.ZeroMean())
+
+Constructor for the LinearOperatorGP model.
+
+Arguments:
+- `base_kernel`: The kernel of the latent GP.
+- `ops`: A collection of linear operators to apply to the latent GP.
+- `noise_var`: The noise variance. Accepts a `Real`, a `Tuple` of length p, or an
+    `AbstractVector` of length n (see `_build_noise` for details).
+- `mean`: (optional) The mean function of the latent GP, defaults to `ZeroMean()`.
+
+returns:
+- `LinearOperatorGP`: An instance of the LinearOperatorGP model with no posterior.
+"""
+function LinearOperatorGP(base_kernel::Kernel, ops, noise_var::T; mean=AbstractGPs.ZeroMean()) where {T}
+    inner, scale, lengthscale = extract_scale_and_lengthscale(base_kernel)
+
+    if lengthscale === nothing
+        inner = with_lengthscale(inner, 1.0)
+    else
+        inner = with_lengthscale(inner, lengthscale)
+    end
+
+    if scale == 1.0 && !isa(base_kernel, AbstractGPs.ScaledKernel)
+        base_kernel = ScaledKernel(inner, 1.0)
+    else
+        base_kernel = ScaledKernel(inner, scale)
+    end
+
+    p = length(ops)
+    wrapped_mean = LinearOperatorMean(mean, ops)
+    wrapped_kernel = LinearOperatorKernel(base_kernel, ops)
+    gp = AbstractGPs.GP(wrapped_mean, wrapped_kernel)
+
+    return LinearOperatorGP(gp, noise_var, ops, p, nothing)
+end
+
+"""
+    Base.copy(model::LinearOperatorGP)
+
+Create a shallow copy of the LinearOperatorGP instance.
+
+Arguments:
+- `model::LinearOperatorGP`: The model to copy.
+
+returns:
+- `LinearOperatorGP`: A new instance with the same fields.
+"""
+Base.copy(model::LinearOperatorGP) = LinearOperatorGP(
+    model.gp,
+    model.noise_var,
+    model.ops,
+    model.p,
+    copy(model.gpx),
+)
+
+"""
+    update(model::LinearOperatorGP, xs::AbstractVector{<:Tuple}, ys::AbstractVector{<:Real})
+
+Update the LinearOperatorGP with heterogeneous (tagged) observations. Each input is a
+`(x, i)` tuple explicitly specifying which operator was applied at that point.
+
+Arguments:
+- `model::LinearOperatorGP`: The current model.
+- `xs::AbstractVector{<:Tuple}`: Tagged input points of the form `(x, i)`.
+- `ys::AbstractVector{<:Real}`: Scalar observations corresponding to each tagged input.
+
+returns:
+- `LinearOperatorGP`: A new model conditioned on the provided data.
+
+Throws:
+- `ArgumentError`: If `length(xs) ≠ length(ys)`.
+"""
+function update(model::LinearOperatorGP, xs::AbstractVector{<:Tuple}, ys::AbstractVector{<:Real})
+    length(xs) == length(ys) || throw(ArgumentError("xs and ys must have the same length"))
+    noise = _build_noise(model.noise_var, xs)
+    gpx = model.gp(xs, noise)
+    updated_gpx = posterior(gpx, ys)
+    return LinearOperatorGP(model.gp, model.noise_var, model.ops, model.p, updated_gpx)
+end
+
+"""
+    update(model::LinearOperatorGP, xs::AbstractVector, ys::AbstractVector{<:AbstractVector})
+
+Update the LinearOperatorGP with full observations, where each input point has a
+full vector of outputs (one per operator).
+
+Arguments:
+- `model::LinearOperatorGP`: The current model.
+- `xs::AbstractVector`: Input points, one per observation location.
+- `ys::AbstractVector{<:AbstractVector}`: Output vectors, one per input point, each of
+    length p (one entry per operator).
+
+returns:
+- `LinearOperatorGP`: A new model conditioned on the provided data.
+"""
+function update(model::LinearOperatorGP, xs::AbstractVector, ys::AbstractVector{<:AbstractVector})
+    x_tilde, y_tilde = prepare_isotopic_multi_output_data(xs, ColVecs(reduce(hcat, ys)))
+    noise = _build_noise(model.noise_var, x_tilde)
+    gpx = model.gp(x_tilde, noise)
+    updated_gpx = posterior(gpx, y_tilde)
+    return LinearOperatorGP(model.gp, model.noise_var, model.ops, model.p, updated_gpx)
+end
+
+"""
+    posterior_mean(model::LinearOperatorGP, x, i=1)
+
+Compute the posterior mean of the GP at input `x` for operator index `i`.
+
+Arguments:
+- `model::LinearOperatorGP`: The conditioned model.
+- `x`: The input point.
+- `i::Int`: (optional) The operator index, defaults to 1.
+
+returns:
+- `AbstractVector`: The posterior mean at `x` under operator `i`.
+"""
+function posterior_mean(model::LinearOperatorGP, x::Union{Real,AbstractVector}, i::Int=1)
+    x = x isa Real ? [x] : x
+    return mean(model.gpx([(x, i)]))
+end
+
+"""
+    posterior_var(model::LinearOperatorGP, x, i=1)
+
+Compute the posterior variance of the GP at input `x` for operator index `i`.
+
+Arguments:
+- `model::LinearOperatorGP`: The conditioned model.
+- `x`: The input point.
+- `i::Int`: (optional) The operator index, defaults to 1.
+
+returns:
+- `AbstractVector`: The posterior variance at `x` under operator `i`.
+"""
+function posterior_var(model::LinearOperatorGP, x::Union{Real,AbstractVector}, i::Int=1)
+    x = x isa Real ? [x] : x
+    return var(model.gpx([(x, i)]))
+end
+
+"""
+    prep_input(model::LinearOperatorGP, xs)
+
+Prepare input data into the tagged format expected by the multi-output GP.
+
+Arguments:
+- `model::LinearOperatorGP`: The model (used to read `p`).
+- `xs`: Raw input points.
+
+returns:
+- Prepared input in `MOInputIsotopicByOutputs` or tagged-tuple format.
+"""
+prep_input(model::LinearOperatorGP, xs) = _prep_input(xs, model.p)
+
+"""
+    prep_output(model::LinearOperatorGP, ys::AbstractVector)
+
+Flatten a vector of per-point output vectors into the column-major ordering expected
+by `MOInputIsotopicByOutputs`.
+
+Arguments:
+- `model::LinearOperatorGP`: The model.
+- `ys::AbstractVector`: A vector of output vectors, one per input point.
+
+returns:
+- `AbstractVector`: The flattened output vector in isotopic column-major order.
+"""
+function prep_output(model::LinearOperatorGP, ys::AbstractVector)
+    return vec(permutedims(reduce(hcat, ys)))
+end
+
+"""
+    _build_noise(noise_var::Real, xs::AbstractVector)
+
+Build a uniform diagonal noise matrix from a scalar variance.
+
+Arguments:
+- `noise_var::Real`: A single noise variance applied to all observations.
+- `xs::AbstractVector`: The vector of input points (used only to determine length).
+    In the full observation case, `xs` is the prepped input vector of length n*p,
+    as returned by `_prep_input`, where n is the number of observation locations
+    and p is the number of operators.
+
+returns:
+- `Diagonal`: A diagonal noise matrix of size (n*p)×(n*p) with constant diagonal `noise_var`.
+"""
+function _build_noise(noise_var::Real, xs::AbstractVector)
+    return Diagonal(fill(noise_var, length(xs)))
+end
+
+"""
+    _build_noise(noise_var::Tuple, xs::AbstractVector{<:Tuple})
+
+Build a diagonal noise matrix from a per-operator noise tuple, for heterogeneous
+(tagged) inputs where each element of `xs` is a `(x, i)` tuple with operator index `i`.
+In this case `xs` is the raw unprepped input vector, as different operators may be
+observed at different locations.
+
+Arguments:
+- `noise_var::Tuple`: A tuple of length p, one noise variance per operator type.
+- `xs::AbstractVector{<:Tuple}`: Tagged input points of the form `(x, i)`.
+
+returns:
+- `Diagonal`: A diagonal noise matrix with each entry set to `noise_var[i]`
+    for the corresponding operator index `i`.
+"""
+function _build_noise(noise_var::Tuple, xs::AbstractVector{<:Tuple})
+    return Diagonal([noise_var[i] for (_, i) in xs])
+end
+
+"""
+    _build_noise(noise_var::Tuple, xs::AbstractVector)
+
+Build a diagonal noise matrix from a per-operator noise tuple, for the full observation
+case where all p operators are observed at every input location. `xs` is the prepped
+input vector of length n*p, as returned by `_prep_input` via `MOInputIsotopicByOutputs`,
+ordered as all outputs for location 1, then location 2, ..., location n.
+
+Arguments:
+- `noise_var::Tuple`: A tuple of length p, one noise variance per operator type.
+- `xs::AbstractVector`: Prepped isotopic input points of length n*p (not tagged).
+
+returns:
+- `Diagonal`: A diagonal noise matrix of size (n*p)×(n*p) where each block of n
+    consecutive entries corresponds to one operator's noise variance.
+"""
+function _build_noise(noise_var::Tuple, xs::AbstractVector)
+    n = length(xs)
+    p = length(noise_var)
+    return Diagonal(repeat(collect(noise_var), inner = div(n, p)))
+end
+
+"""
+    _build_noise(noise_var::AbstractVector, xs::AbstractVector)
+
+Build a diagonal noise matrix from a per-observation noise vector.
+
+Arguments:
+- `noise_var::AbstractVector`: A vector of length n, one noise variance per observation.
+    In the full observation case, n = n_locations * p and `xs` is the prepped input
+    vector as returned by `_prep_input`.
+- `xs::AbstractVector`: The vector of input points.
+
+returns:
+- `Diagonal`: A diagonal noise matrix with `noise_var` on the diagonal.
+
+Throws:
+- `ArgumentError`: If `length(noise_var) ≠ length(xs)`.
+"""
+function _build_noise(noise_var::AbstractVector, xs::AbstractVector)
+    length(noise_var) == length(xs) || throw(ArgumentError(
+        "noise_var length ($(length(noise_var))) must match number of observations ($(length(xs)))"
+    ))
+    return Diagonal(noise_var)
+end
+
+"""
+    get_mean_std(model::LinearOperatorGP, y_train::AbstractVector, choice::String)
+
+Compute the empirical mean and standard deviation of the training outputs, used for
+standardizing the GP before training. Only the first output (function values) is used
+for centering; gradient outputs are scaled by the same factor.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+- `y_train::AbstractVector`: A vector of output vectors, one per training point.
+- `choice::String`: Standardization mode. `"scale_only"` sets mean to zero,
+    `"mean_only"` sets standard deviation to one, anything else does both.
+
+returns:
+- `μ::Vector`: The empirical mean vector (zero for all but the first output).
+- `σ::Vector`: The empirical standard deviation vector (same value for all outputs).
+"""
+function get_mean_std(model::LinearOperatorGP, y_train::AbstractVector, choice::String)
+    y_mat = reduce(hcat, y_train)
+
+    μ = vec(mean(y_mat; dims=2))
+    μ[2:end] .= 0.0
+
+    σ = vec(std(y_mat; dims=2))
+    σ[σ .== 0.0] .= 1.0
+    σ[2:end] .= σ[1]
+
+    if choice == "scale_only"
+        μ .= 0.0
+    elseif choice == "mean_only"
+        σ .= 1.0
+    end
+
+    return μ, σ
+end
+
+"""
+    std_y(model::LinearOperatorGP, ys::AbstractVector, μ::AbstractVector, σ::AbstractVector)
+
+Standardize the training outputs using the provided mean and standard deviation.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+- `ys::AbstractVector`: A vector of output vectors, one per training point.
+- `μ::AbstractVector`: The mean vector to subtract.
+- `σ::AbstractVector`: The standard deviation vector to divide by.
+
+returns:
+- `Vector`: A vector of standardized output vectors.
+"""
+function std_y(model::LinearOperatorGP, ys::AbstractVector, μ::AbstractVector, σ::AbstractVector)
+    return [(y .- μ) ./ σ[1] for y in ys]
+end
+
+"""
+    _get_minimum(model::LinearOperatorGP, ys::Vector{Y}) where {Y}
+
+Extract the minimum function value (first output) across all training points.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+- `ys::Vector{Y}`: A vector of output vectors, one per training point.
+
+returns:
+- The minimum value of the first output across all training points.
+"""
+_get_minimum(model::LinearOperatorGP, ys::Vector{Y}) where {Y} = minimum(hcat(ys...)[1, :])[1]
+
+"""
+    get_lengthscale(model::LinearOperatorGP)
+
+Get the lengthscale of the base kernel of the latent GP.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+
+returns:
+- `Vector`: The lengthscale of the base kernel.
+"""
+get_lengthscale(model::LinearOperatorGP) = 1 ./ model.gp.kernel.base_kernel.kernel.transform.s
+
+"""
+    get_scale(model::LinearOperatorGP)
+
+Get the output scale of the base kernel of the latent GP.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+
+returns:
+- `Vector`: The output scale of the base kernel.
+"""
+get_scale(model::LinearOperatorGP) = model.gp.kernel.base_kernel.σ²
+
+"""
+    get_kernel_constructor(model::LinearOperatorGP)
+Get the kernel constructor of the GP model.
+
+Arguments:
+- 'model::LinearOperatorGP': The GP model.
+
+returns:
+- 'get_kernel_constructor::Kernel': The kernel constructor of the GP model.
+"""
+get_kernel_constructor(model::LinearOperatorGP) = model.gp.kernel.base_kernel.kernel.kernel
+
+"""
+    nlml(model::LinearOperatorGP, params, xs::AbstractVector, ys::AbstractVector{<:AbstractVector})
+
+Compute the negative log marginal likelihood (NLML) of the GP model given hyperparameters,
+for the full observation case where all operators are observed at every input point.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+- `params`: Parameters containing the log lengthscale and log scale.
+- `xs::AbstractVector`: The input data points.
+- `ys::AbstractVector{<:AbstractVector}`: The observed values, one vector of length p
+    per input point (one entry per operator).
+
+returns:
+- `Float64`: The negative log marginal likelihood of the model.
+"""
+function nlml(model::LinearOperatorGP, params, xs::AbstractVector, ys::AbstractVector{<:AbstractVector})
+    log_ℓ, log_scale = params
+    ℓ = exp(log_ℓ)
+    scale = exp(log_scale)
+
+    kernel_constructor::Kernel = get_kernel_constructor(model)
+    k = scale * with_lengthscale(kernel_constructor, ℓ)
+
+    gp = LinearOperatorGP(k, model.ops, model.noise_var; mean=model.gp.mean.base_mean)
+    x_tilde, y_tilde = prepare_isotopic_multi_output_data(xs, ColVecs(reduce(hcat, ys)))
+    noise = _build_noise(model.noise_var, x_tilde)
+    gpx = gp.gp(x_tilde, noise)
+
+    return -AbstractGPs.logpdf(gpx, y_tilde)
+end
+
+"""
+    nlml(model::LinearOperatorGP, params, xs::AbstractVector{<:Tuple}, ys::AbstractVector{<:Real})
+
+Compute the negative log marginal likelihood (NLML) of the GP model given hyperparameters,
+for the partial observation case where each input is a tagged tuple `(x, i)` specifying
+which operator was applied, allowing different operators to be observed at different points.
+
+Arguments:
+- `model::LinearOperatorGP`: The GP model.
+- `params`: Parameters containing the log lengthscale and log scale.
+- `xs::AbstractVector{<:Tuple}`: Tagged input points of the form `(x, i)`.
+- `ys::AbstractVector{<:Real}`: Scalar observations corresponding to each tagged input.
+
+returns:
+- `Float64`: The negative log marginal likelihood of the model.
+"""
+function nlml(model::LinearOperatorGP, params, xs::AbstractVector{<:Tuple}, ys::AbstractVector{<:Real})
+    log_ℓ, log_scale = params
+    ℓ = exp(log_ℓ)
+    scale = exp(log_scale)
+
+    # Kernel with current parameters
+    kernel_constructor::Kernel = get_kernel_constructor(model)
+    k = scale * with_lengthscale(kernel_constructor, ℓ)
+
+    # GP with current parameters
+    gp = LinearOperatorGP(k, model.ops, model.noise_var; mean=model.gp.mean.base_mean)
+    gpx = gp.gp(xs, model.noise_var)
+
+    return -AbstractGPs.logpdf(gpx, ys)  # Negative log marginal likelihood
+end
+
+

--- a/src/surrogates/surrogates_utils.jl
+++ b/src/surrogates/surrogates_utils.jl
@@ -45,3 +45,19 @@ function extract_scale_and_lengthscale(kernel::Kernel)
 
     return (inner, scale, lengthscale)
 end
+
+function _prep_input(x::AbstractVector{X}, p::Int) where {X}
+    return KernelFunctions.MOInputIsotopicByOutputs(x, p)
+end
+
+function _prep_input(x::AbstractVector{<:Tuple{X,Int}}, p::Int) where {X}
+    return x
+end
+
+function _prep_input(x::Tuple{X,Int}, p::Int) where {X}
+    return [x]
+end
+
+function _prep_input(x::X, p::Int) where {X<:Real}
+    return _prep_input([x], p)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,3 @@
-using Pkg
-Pkg.activate(dirname(@__DIR__))
-
 using AbstractBayesOpt
 
 using AbstractBayesOpt:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+using Pkg
+Pkg.activate(dirname(@__DIR__))
+
 using AbstractBayesOpt
 
 using AbstractBayesOpt:
@@ -10,7 +13,15 @@ using AbstractBayesOpt:
     get_mean_std,
     print_info,
     rescale_output,
-    lengthscale_bounds
+    lengthscale_bounds,
+    _unitvec,
+    _scalar_mean,
+    _build_noise,
+    _prep_input,
+    prep_output,
+    make_linear_operator_mean,
+    get_kernel_constructor
+
 
 using Test
 using AbstractGPs

--- a/test/test_surrogates.jl
+++ b/test/test_surrogates.jl
@@ -413,4 +413,622 @@ using LinearAlgebra
             @test copied_gp.gpx !== updated_gp.gpx  # Should be different reference
         end
     end
+
+    @testset "LinearOperatorGP Tests" begin
+        @testset "AbstractLinearOperator Construction" begin
+            # Test IdentityOperator
+            Id = IdentityOperator()
+            @test isa(Id, IdentityOperator)
+
+            # Test PartialDerivative
+            ∂_1 = PartialDerivative(1)
+            ∂_2 = PartialDerivative(2)
+            @test isa(∂_1, PartialDerivative)
+            @test ∂_1.dim == 1
+            @test isa(∂_2, PartialDerivative)
+            @test ∂_2.dim == 2
+
+            # Test LaplacianOperator
+            ∆ = LaplacianOperator()
+            @test isa(∆, LaplacianOperator)
+        end
+
+        @testset "AbstractLinearOperator evaluation" begin
+            # Functions used as reference 
+            f(x) = x[1]^2 + x[2]^2 
+            g(x) = x[1]^2
+            h(x) = x[2]^2 + 0.25
+            k(x) = x[1]*x[2]^2
+            
+            # Test IdentityOperator evaluation for a selected set of points S 
+            S = [[-5, -5], [-5, 5], [5, -5], [5, 5], [-2.5, -2.5], [-2.5, 2.5], [2.5, -2.5], [2.5, 2.5], [0.0, 0.0]]
+            f_S = [50, 50, 50, 50, 12.5, 12.5, 12.5, 12.5, 0.0]
+            g_S = [25, 25, 25, 25, 6.25, 6.25, 6.25, 6.25, 0.0]
+            h_S = [25.25, 25.25, 25.25, 25.25, 6.5, 6.5, 6.5, 6.5, 0.25]
+
+            @test all(IdentityOperator()(f, x) == y for (x, y) in zip(S, f_S))
+            @test all(IdentityOperator()(g, x) == y for (x, y) in zip(S, g_S))
+            @test all(IdentityOperator()(h, x) == y for (x, y) in zip(S, h_S))
+
+            # Test PartialDerivative evaluation over the same set S
+            ∂_1f(x) = 2*x[1]
+            ∂_2f(x) = 2*x[2]
+            
+            ∂_1g(x) = 2*x[1]
+            ∂_2g(x) = 0.0
+
+            ∂_1h(x) = 0.0
+            ∂_2h(x) = 2*x[2]
+
+            @test all(isapprox(PartialDerivative(1)(f, x), ∂_1f(x), atol=1e-10) && isapprox(PartialDerivative(2)(f, x), ∂_2f(x), atol=1e-10) for x in S)
+            @test all(isapprox(PartialDerivative(1)(g, x), ∂_1g(x), atol=1e-10) && isapprox(PartialDerivative(2)(g, x), ∂_2g(x), atol=1e-10) for x in S)
+            @test all(isapprox(PartialDerivative(1)(h, x), ∂_1h(x), atol=1e-10) && isapprox(PartialDerivative(2)(h, x), ∂_2h(x), atol=1e-10) for x in S)
+
+            # Test LaplacianOperator evaluation over S
+            ∆f(x) = 4.0
+            ∆g(x) = 2.0
+            ∆h(x) = 2.0
+            ∆k(x) = 2*x[1]
+
+            @test all(isapprox(LaplacianOperator()(f, x), ∆f(x), atol=1e-10) for x in S)
+            @test all(isapprox(LaplacianOperator()(g, x), ∆g(x), atol=1e-10) for x in S)
+            @test all(isapprox(LaplacianOperator()(h, x), ∆h(x), atol=1e-10) for x in S)
+            @test all(isapprox(LaplacianOperator()(k, x), ∆k(x), atol=1e-10) for x in S)
+        end
+
+        @testset "Helper functions" begin
+            @testset "_unitvec" begin
+                n = 6
+                vec = fill(0.5, n)
+                
+                @test all(length(_unitvec(vec, i)) == n && _unitvec(vec, i) == [j == i ? one(eltype(vec)) : zero(eltype(vec)) for j in 1:n]
+                          for i in 1:n)
+            end
+
+            @testset "_scalar_mean" begin
+                # Test _scalar_mean evaluation over the set m_set for the base mean m
+                m_set = [[-5, 6.5], [68.43, -50], [13, 4], [2.4, 5.6]]
+                m = CustomMean(x -> x[1] + x[2])
+
+                @test all(isa(_scalar_mean(m, x), Float64) && isapprox(_scalar_mean(m, x), x[1] + x[2], atol=1e-10) for x in m_set)
+            end
+
+            @testset "_build_noise" begin
+                # Test for _build_noise(noise_var::Real, xs::AbstractVector)
+                noise_var_1 = 0.1
+                xs_1 = [1.0, 2.3, 5.6]
+                n_1 = length(xs_1)
+                true_∑_1 = 0.1*Diagonal(ones(n_1))
+                ∑_1 = _build_noise(noise_var_1, xs_1)
+                @test isa(∑_1, Diagonal) && size(∑_1) == (n_1, n_1) && ∑_1 == true_∑_1 
+
+                # Test for _build_noise(noise_var::Tuple, xs::AbstractVector{<:Tuple})
+                noise_var_2 = (0.4, 0.1, 1.2)
+                xs_2 = [(4.2, 2), (5.3, 1), (6.0, 2), (3.1, 3), (0.7, 1)]
+                n_2 = length(xs_2)
+                true_∑_2 = Diagonal([0.1, 0.4, 0.1, 1.2, 0.4])
+                ∑_2 = _build_noise(noise_var_2, xs_2)
+
+                @test isa(∑_2, Diagonal) && size(∑_2) == (n_2, n_2) && ∑_2 == true_∑_2
+
+                # Test for _build_noise(noise_var::Tuple, xs::AbstractVector)
+                noise_var_3 = (0.4, 0.1, 1.2)
+                xs_3 = [4.2, 2.0, 15.1, 12.7, 2.7, 7.9]
+                n_3 = length(xs_3)
+                true_∑_3 = Diagonal([0.4, 0.4, 0.1, 0.1, 1.2, 1.2])
+                ∑_3 = _build_noise(noise_var_3, xs_3)
+
+                @test isa(∑_3, Diagonal) && size(∑_3) == (n_3, n_3) && ∑_3 == true_∑_3
+
+                # Test for _build_noise(noise_var::AbstractVector, xs::AbstractVector)
+                noise_var_4 = [0.3, 0.1, 1.3, 0.7, 1.5]
+                xs_4 = [4.0, 1.9, 4.5, 21.8, 17.2]
+                n_4 = length(xs_4)
+                true_∑_4 = Diagonal(noise_var_4)
+                ∑_4 = _build_noise(noise_var_4, xs_4)
+
+                @test isa(∑_4, Diagonal) && size(∑_4) == (n_4, n_4) && ∑_4 == true_∑_4
+
+                noise_var_4_bad = [0.3, 0.1, 1.3, 0.7]
+                @test_throws ArgumentError _build_noise(noise_var_4_bad, xs_4)
+            end
+
+            @testset "_prep_input" begin
+                xs = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+                p = 3
+            
+                # Test _prep_input(xs::AbstractVector{X}, p::Int)
+                prepped_1 = _prep_input(xs, p)
+                @test isa(prepped_1, KernelFunctions.MOInputIsotopicByOutputs)
+                @test prepped_1.x == xs
+                @test prepped_1.out_dim == p
+            
+                # Test _prep_input(xs::AbstractVector{<:Tuple}, p::Int)
+                xs_tagged = [(x, i) for x in xs for i in 1:p]
+                prepped_2 = _prep_input(xs_tagged, p)
+                @test prepped_2 === xs_tagged
+            
+                # Test _prep_input(x::Tuple, p::Int)
+                x_single = ([1.0, 2.0], 2)
+                prepped_3 = _prep_input(x_single, p)
+                @test isa(prepped_3, Vector)
+                @test length(prepped_3) == 1
+                @test prepped_3[1] === x_single
+            
+                # Test _prep_input(x::Real, p::Int)
+                x_real = 1.5
+                prepped_4 = _prep_input(x_real, p)
+                @test isa(prepped_4, KernelFunctions.MOInputIsotopicByOutputs)
+                @test prepped_4.x == [x_real]
+                @test prepped_4.out_dim == p
+            end
+        end
+
+        @testset "LinearOperatorGP Construction" begin
+            # Base mean and kernel functions 
+            base_mean = CustomMean(x -> (x[1]^2)*(x[2]^2) + x[1]^2 + x[2]^2)
+            base_kernel = SqExponentialKernel()
+
+            # Operators considered
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+
+            # Test LinearOperatorMean construction
+            linop_mean = LinearOperatorMean(base_mean, ops)
+            @test isa(linop_mean, LinearOperatorMean)
+
+            # Test LinearOperatorKernel construction
+            linop_kernel = LinearOperatorKernel(base_kernel, ops)
+            @test isa(linop_kernel, LinearOperatorKernel)
+
+            # Test LinearOperatorGP construction
+            noise_var = 0.1
+            p = 4 # =length(ops)
+            gp = LinearOperatorGP(base_kernel, ops, noise_var; mean = base_mean)
+
+            @test gp.noise_var == noise_var
+            @test gp.p == p
+            @test gp.gpx === nothing
+            @test isa(gp.gp, AbstractGPs.GP)
+        end
+
+        @testset "LinearOperatorGP Utility Functions" begin
+            @testset "prep_input and prep_output" begin
+                ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+                kernel = SqExponentialKernel()
+                noise_var = 0.1
+                model = LinearOperatorGP(kernel, ops, noise_var)
+            
+                xs = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+                p = model.p
+            
+                # Test prep_input
+                prepped = prep_input(model, xs)
+                @test isa(prepped, KernelFunctions.MOInputIsotopicByOutputs)
+                @test prepped.x == xs
+                @test prepped.out_dim == p
+            
+                # Test prep_output
+                ys = [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]
+                prepped_out = prep_output(model, ys)
+                true_out = vec(permutedims(reduce(hcat, ys)))
+                @test isa(prepped_out, AbstractVector)
+                @test length(prepped_out) == length(xs) * p
+                @test prepped_out == true_out
+            end
+
+            @testset "get_scale, get_lengthscale and get_kernel_constructor" begin
+                # Base mean and kernel functions 
+                base_mean = CustomMean(x -> (x[1]^2)*(x[2]^2) + x[1]^2 + x[2]^2)
+                base_kernel = SqExponentialKernel()
+
+                # Operators considered
+                ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+                
+                noise_var = 0.1
+                p = 4 # =length(ops)
+                gp = LinearOperatorGP(base_kernel, ops, noise_var; mean = base_mean)
+                
+                # Test the kernel with lengthscale and scale
+                ℓ = get_lengthscale(gp)[1]
+                scale = get_scale(gp)[1]
+                @test ℓ == 1.0
+                @test scale == 1.0
+
+                # Test with custom lengthscale and scale
+                custom_ℓ = 0.5
+                custom_scale = 2.0
+                custom_kernel = custom_scale * (with_lengthscale(base_kernel, custom_ℓ))
+                gp_custom = LinearOperatorGP(custom_kernel, ops, noise_var)
+                @test get_lengthscale(gp_custom) == [custom_ℓ]
+                @test get_scale(gp_custom) == [custom_scale]
+                @test gp_custom.noise_var == noise_var
+                @test gp_custom.gpx === nothing
+                @test isa(gp_custom.gp, AbstractGPs.GP)
+
+                # Test with only lengthscale
+                custom_ℓ_2 = 0.6
+                ls_kernel = with_lengthscale(base_kernel, custom_ℓ_2)
+                gp_ls = LinearOperatorGP(ls_kernel, ops, noise_var)
+                @test get_lengthscale(gp_ls) == [custom_ℓ_2]
+                @test get_scale(gp_ls) == [1.0] # default scale
+                @test gp_ls.noise_var == noise_var
+                @test gp_ls.gpx === nothing
+                @test isa(gp_ls.gp, AbstractGPs.AbstractGP)
+
+                # Test with only scale
+                custom_scale_2 = 2.5
+                sc_kernel = custom_scale_2 * base_kernel
+                gp_sc = LinearOperatorGP(sc_kernel, ops, noise_var)
+                @test get_lengthscale(gp_sc) == [1.0] # default length
+                @test get_scale(gp_sc) == [custom_scale_2]
+                @test gp_sc.noise_var == noise_var
+                @test gp_sc.gpx === nothing
+                @test isa(gp_sc.gp, AbstractGPs.AbstractGP)
+
+                # Test get_kernel_constructor 
+                ad_kernel_52 = ADMatern52Kernel()
+                ad_kernel_72 = ADMatern72Kernel()
+                gp_52 = LinearOperatorGP(ad_kernel_52, ops, noise_var)
+                gp_72 = LinearOperatorGP(ad_kernel_72, ops, noise_var)
+
+                @test isa(get_kernel_constructor(gp), SqExponentialKernel)
+                @test isa(get_kernel_constructor(gp_52), ADMatern52Kernel)
+                @test isa(get_kernel_constructor(gp_72), ADMatern72Kernel)
+            end
+
+            @testset "get_mean_std and std_y" begin
+                base_kernel = SqExponentialKernel()
+                ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+                noise_var = 0.1
+                gp = LinearOperatorGP(base_kernel, ops, noise_var)
+            
+                y_train = [[0.1, 1.0, 2.0, 0.5], [0.2, 2.0, 3.0, 1.5], [0.3, 3.0, 4.0, 2.5]]
+            
+                # Default: mean and scale
+                μ, σ = get_mean_std(gp, y_train, "mean_scale")
+                y_std = std_y(gp, y_train, μ, σ)
+            
+                @test length(μ) == gp.p
+                @test length(σ) == gp.p
+                @test length(y_std) == length(y_train)
+                @test all(length(y) == gp.p for y in y_std)
+            
+                @test μ ≈ [0.2, 0.0, 0.0, 0.0]
+                @test σ ≈ [0.1, 0.1, 0.1, 0.1]
+            
+                true_y_std = [[-1.0, 10.0, 20.0, 5.0], [ 0.0, 20.0, 30.0, 15.0], [ 1.0, 30.0, 40.0, 25.0]]
+            
+                @test y_std ≈ true_y_std
+            
+                # scale_only: mean forced to zero
+                μ_scale, σ_scale = get_mean_std(gp, y_train, "scale_only")
+                @test μ_scale ≈ zeros(gp.p)
+                @test σ_scale ≈ [0.1, 0.1, 0.1, 0.1]
+            
+                # mean_only: std forced to one
+                μ_mean, σ_mean = get_mean_std(gp, y_train, "mean_only")
+                @test μ_mean ≈ [0.2, 0.0, 0.0, 0.0]
+                @test σ_mean ≈ ones(gp.p)
+            
+                # Constant first output: zero std replaced by one
+                y_constant = [[1.0, 2.0, 3.0, 4.0], [1.0, 5.0, 6.0, 7.0], [1.0, 8.0, 9.0, 10.0]]
+            
+                μ_const, σ_const = get_mean_std(gp, y_constant, "mean_scale")
+            
+                @test μ_const ≈ [1.0, 0.0, 0.0, 0.0]
+                @test σ_const ≈ ones(gp.p)
+            
+                y_const_std = std_y(gp, y_constant, μ_const, σ_const)
+            
+                @test y_const_std ≈ [[0.0, 2.0, 3.0, 4.0], [0.0, 5.0, 6.0, 7.0], [0.0, 8.0, 9.0, 10.0]]
+            end
+        end
+
+        @testset "LinearOperatorMean Functionality" begin
+            base_mean = CustomMean(x -> x[1]^2 + x[2]^2)
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+            linop_mean = LinearOperatorMean(base_mean, ops)
+        
+            x = [2.0, 3.0]
+            xs_tagged = [(x, 1), (x, 2), (x, 3), (x, 4)]
+
+            m_vec = AbstractGPs.mean_vector(linop_mean, xs_tagged)
+            @test m_vec ≈ [13.0, 4.0, 6.0, 4.0]
+        
+            custom_mean = make_linear_operator_mean(base_mean, ops)
+            m_custom_vec = AbstractGPs.mean_vector(custom_mean, xs_tagged)
+            @test m_custom_vec ≈ m_vec
+        end
+
+        @testset "LinearOperatorKernel Functionality" begin
+            base_kernel = SqExponentialKernel()
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+            linop_kernel = LinearOperatorKernel(base_kernel, ops)
+        
+            x = [0.5, 0.5]
+            y = [0.6, 0.7]
+        
+            ∇₁kernel(x, y) = ForwardDiff.gradient(a -> base_kernel(a, y), x)
+            ∇₂kernel(x, y) = ForwardDiff.gradient(b -> base_kernel(x, b), y)
+        
+            ∂₁∂₂kernel(x, y, i, j) = ForwardDiff.derivative(
+                h1 -> ForwardDiff.derivative(
+                    h2 -> base_kernel(
+                        x .+ h1 .* _unitvec(x, i),
+                        y .+ h2 .* _unitvec(y, j),
+                    ),
+                    0.0,
+                ),
+                0.0,
+            )
+        
+            Δ₁kernel(x, y) = tr(ForwardDiff.hessian(a -> base_kernel(a, y), x))
+            Δ₂kernel(x, y) = tr(ForwardDiff.hessian(b -> base_kernel(x, b), y))
+
+            ∂ᵢΔ₂kernel(x, y, i) = ForwardDiff.derivative(h -> Δ₂kernel(x .+ h .* _unitvec(x, i), y), 0.0)
+            Δ₁∂ᵢkernel(x, y, j) = tr(ForwardDiff.hessian(a -> ∇₂kernel(a, y)[j], x))
+
+            Δ₁Δ₂kernel(x, y) = tr(ForwardDiff.hessian(a -> Δ₂kernel(a, y), x))
+        
+            # Identity-Identity
+            @test linop_kernel((x, 1), (y, 1)) ≈ base_kernel(x, y)
+        
+            # Identity-PartialDerivative
+            @test linop_kernel((x, 1), (y, 2)) ≈ ∇₂kernel(x, y)[1]
+            @test linop_kernel((x, 1), (y, 3)) ≈ ∇₂kernel(x, y)[2]
+        
+            # PartialDerivative-Identity
+            @test linop_kernel((x, 2), (y, 1)) ≈ ∇₁kernel(x, y)[1]
+            @test linop_kernel((x, 3), (y, 1)) ≈ ∇₁kernel(x, y)[2]
+        
+            # PartialDerivative-PartialDerivative
+            @test linop_kernel((x, 2), (y, 2)) ≈ ∂₁∂₂kernel(x, y, 1, 1)
+            @test linop_kernel((x, 2), (y, 3)) ≈ ∂₁∂₂kernel(x, y, 1, 2)
+            @test linop_kernel((x, 3), (y, 2)) ≈ ∂₁∂₂kernel(x, y, 2, 1)
+            @test linop_kernel((x, 3), (y, 3)) ≈ ∂₁∂₂kernel(x, y, 2, 2)
+        
+            # Identity-Laplacian and Laplacian-Identity
+            @test linop_kernel((x, 1), (y, 4)) ≈ Δ₂kernel(x, y)
+            @test linop_kernel((x, 4), (y, 1)) ≈ Δ₁kernel(x, y)
+            
+            # PartialDerivative-Laplacian
+            @test linop_kernel((x, 2), (y, 4)) ≈ ∂ᵢΔ₂kernel(x, y, 1)
+            @test linop_kernel((x, 3), (y, 4)) ≈ ∂ᵢΔ₂kernel(x, y, 2)
+
+            # Laplacian-PartialDerivative
+            @test linop_kernel((x, 4), (y, 2)) ≈ Δ₁∂ᵢkernel(x, y, 1)
+            @test linop_kernel((x, 4), (y, 3)) ≈ Δ₁∂ᵢkernel(x, y, 2)
+
+            # Laplacian-Laplacian
+            @test linop_kernel((x, 4), (y, 4)) ≈ Δ₁Δ₂kernel(x, y)
+
+            # Symmetry for function-function case
+            @test linop_kernel((x, 1), (y, 1)) ≈ linop_kernel((y, 1), (x, 1))
+        end
+
+        @testset "LinearOperatorGP Updates" begin
+            @testset "Full observation case" begin
+                base_kernel = SqExponentialKernel()
+                ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+                noise_var = 0.1
+                gp = LinearOperatorGP(base_kernel, ops, noise_var)
+            
+                xs = [[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]]
+                ys = [[1.0, 0.1, 0.1, 2.0], [0.5, 0.0, 0.0, 2.0], [0.0, -0.1, -0.1, 2.0]]
+                updated_gp = update(gp, xs, ys)
+            
+                # Return type and immutability of update
+                @test isa(updated_gp, LinearOperatorGP)
+                @test updated_gp !== gp
+            
+                # Fields preserved
+                @test updated_gp.gp === gp.gp
+                @test updated_gp.noise_var == gp.noise_var
+                @test updated_gp.ops === gp.ops
+                @test updated_gp.p == gp.p
+            
+                # Update actually conditions the model
+                @test gp.gpx === nothing
+                @test updated_gp.gpx !== nothing
+                @test isa(updated_gp.gpx, AbstractGPs.PosteriorGP)
+            
+                # Full-output data is converted to n*p scalar observations
+                x_tilde, y_tilde = prepare_isotopic_multi_output_data(xs, ColVecs(reduce(hcat, ys)))
+                @test length(x_tilde) == length(xs) * gp.p
+                @test length(y_tilde) == length(xs) * gp.p
+            end
+
+            @testset "Heterogeneous observation case" begin
+                base_kernel = SqExponentialKernel()
+                ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+                noise_var = 0.1
+                gp = LinearOperatorGP(base_kernel, ops, noise_var)
+            
+                xs = [
+                    ([0.0, 0.0], 1),
+                    ([0.5, 0.5], 2),
+                    ([1.0, 1.0], 3),
+                    ([1.5, 1.5], 4),
+                    ([2.0, 2.0], 1),
+                ]
+            
+                ys = [1.0, 0.1, -0.1, 2.0, 0.0]
+            
+                updated_gp = update(gp, xs, ys)
+            
+                # Return type and immutability of update
+                @test isa(updated_gp, LinearOperatorGP)
+                @test updated_gp !== gp
+            
+                # Fields preserved
+                @test updated_gp.gp === gp.gp
+                @test updated_gp.noise_var == gp.noise_var
+                @test updated_gp.ops === gp.ops
+                @test updated_gp.p == gp.p
+            
+                # Update actually conditions the model
+                @test gp.gpx === nothing
+                @test updated_gp.gpx !== nothing
+                @test isa(updated_gp.gpx, AbstractGPs.PosteriorGP)
+            
+                # Heterogeneous data is already scalar/tagged
+                @test length(xs) == length(ys)
+            
+                # Tagged inputs should be passed through unchanged by _prep_input
+                @test _prep_input(xs, gp.p) === xs
+            
+                # Length mismatch should throw
+                ys_bad = ys[1:end-1]
+                @test_throws ArgumentError update(gp, xs, ys_bad)
+            end
+        end
+
+        @testset "LinearOperatorGP Posterior Functionality" begin
+            base_kernel = SqExponentialKernel()
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+            noise_var = 0.1
+            gp = LinearOperatorGP(base_kernel, ops, noise_var)
+            
+            # Create training data with full observation
+            xs = [[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]]
+            ys = [[1.0, 0.1, 0.1, 2.0], [0.5, 0.0, 0.0, 2.0], [0.0, -0.1, -0.1, 2.0]]
+        
+            # Updated GP
+            updated_gp = update(gp, xs, ys)
+        
+            # Test predictions
+            test_x = [0.25, 1.25]
+        
+            mean_preds = [posterior_mean(updated_gp, test_x, i) for i in 1:gp.p]
+            var_preds = [posterior_var(updated_gp, test_x, i) for i in 1:gp.p]
+            
+            # Type, length, and variance checks
+            for i in 1:gp.p
+                @test isa(mean_preds[i], AbstractVector)
+                @test isa(var_preds[i], AbstractVector)
+                @test length(mean_preds[i]) == 1
+                @test length(var_preds[i]) == 1
+                @test all(isfinite, mean_preds[i])
+                @test all(isfinite, var_preds[i])
+                @test all(var_preds[i] .≥ 0)
+            end
+            
+            # Manual posterior checks for all operators i = 1, ..., p
+            linop_kernel = updated_gp.gp.kernel
+            x_tilde, y_tilde = prepare_isotopic_multi_output_data(xs, ColVecs(reduce(hcat, ys)))
+            K̃ = kernelmatrix(linop_kernel, x_tilde) + noise_var * I
+        
+            x0 = test_x
+        
+            for i in 1:gp.p
+                test_i = (x0, i)
+        
+                k_xX_i = [linop_kernel(test_i, x_train) for x_train in x_tilde]
+        
+                true_mean_i = k_xX_i' * (K̃ \ y_tilde)
+                true_var_i = linop_kernel(test_i, test_i) - k_xX_i' * (K̃ \ k_xX_i)
+        
+                @test isapprox(mean_preds[i][1], true_mean_i, atol=1e-10)
+                @test isapprox(var_preds[i][1], true_var_i, atol=1e-10)
+            end
+            
+            # Default i omitted should match i = 1
+            mean_pred_default = posterior_mean(updated_gp, test_x)
+            var_pred_default = posterior_var(updated_gp, test_x)
+        
+            @test mean_pred_default ≈ mean_preds[1]
+            @test var_pred_default ≈ var_preds[1]
+        end
+
+        @testset "LinearOperatorGP Copy" begin
+            base_kernel = SqExponentialKernel()
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+            noise_var = 0.1
+            gp = LinearOperatorGP(base_kernel, ops, noise_var)
+
+            xs = [[0.5, 1.3], [23.1, 5.8], [3.8, 4.0]]
+            ys = [[31.0, 0.0, 1.9, 3.0], [6.7, 5.0, 12.3, 4.2], [6.8, 13.4, 20.0, 9.2]]
+            
+            # Unconditioned model
+            copied_gp = copy(gp)
+            @test copied_gp.noise_var == gp.noise_var
+            @test copied_gp.gp === gp.gp
+            @test copied_gp.ops === gp.ops
+            @test copied_gp.gpx === nothing
+
+            # Conditioned model
+            updated_gp = update(gp, xs, ys)
+            copied_updated_gp = copy(updated_gp)
+
+            @test copied_updated_gp.gp === updated_gp.gp
+            @test copied_updated_gp.ops === updated_gp.ops
+            @test copied_updated_gp.noise_var == updated_gp.noise_var
+            @test copied_updated_gp.p == updated_gp.p
+            @test copied_updated_gp.gpx !== updated_gp.gpx
+        end
+
+        @testset "LinearOperatorGP nlml" begin
+            base_kernel = SqExponentialKernel()
+            ops = [IdentityOperator(), PartialDerivative(1), PartialDerivative(2), LaplacianOperator()]
+            noise_var = 0.1
+        
+            kernel = 1.5 * with_lengthscale(base_kernel, 0.8)
+            gp = LinearOperatorGP(kernel, ops, noise_var)
+        
+            params = log.([0.8, 1.5])
+        
+            @testset "Full observation case" begin
+                xs = [[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]]
+                ys = [
+                    [1.0, 0.1, 0.1, 2.0],
+                    [0.5, 0.0, 0.0, 2.0],
+                    [0.0, -0.1, -0.1, 2.0],
+                ]
+        
+                val = nlml(gp, params, xs, ys)
+        
+                x_tilde, y_tilde = prepare_isotopic_multi_output_data(xs, ColVecs(reduce(hcat, ys)))
+                noise = _build_noise(noise_var, x_tilde)
+                gpx = gp.gp(x_tilde, noise)
+        
+                true_val = -AbstractGPs.logpdf(gpx, y_tilde)
+        
+                @test isa(val, Real)
+                @test isfinite(val)
+                @test isapprox(val, true_val, atol=1e-10)
+
+                params_wrong = log.([0.3, 5.0])
+                val_wrong = nlml(gp, params_wrong, xs, ys)
+                @test isfinite(val_wrong)
+                @test val_wrong != val
+            end
+        
+            @testset "Heterogeneous observation case" begin
+                xs = [
+                    ([0.0, 0.0], 1),
+                    ([0.5, 0.5], 2),
+                    ([1.0, 1.0], 3),
+                    ([1.5, 1.5], 4),
+                    ([2.0, 2.0], 1),
+                ]
+        
+                ys = [1.0, 0.1, -0.1, 2.0, 0.0]
+        
+                val = nlml(gp, params, xs, ys)
+        
+                noise = _build_noise(noise_var, xs)
+                gpx = gp.gp(xs, noise)
+        
+                true_val = -AbstractGPs.logpdf(gpx, ys)
+        
+                @test isa(val, Real)
+                @test isfinite(val)
+                @test isapprox(val, true_val, atol=1e-10)
+                params_wrong = log.([0.3, 5.0])
+                val_wrong = nlml(gp, params_wrong, xs, ys)
+                @test isfinite(val_wrong)
+                @test val_wrong != val
+            end
+        end
+    end
 end


### PR DESCRIPTION
This pull request extends the `AbstractBayesOpt` package by introducing support for linear operator Gaussian processes and related utilities. The main changes add new surrogate model types, operators, and utility functions, as well as updating exports and test imports to reflect these additions.

**Additions for Linear Operator Gaussian Processes:**

* Added `LinearOperatorGP` as a new surrogate model, and exported it along with its associated operators: `IdentityOperator`, `PartialDerivative`, and `LaplacianOperator`. (`src/AbstractBayesOpt.jl`)
* Exported new types for linear operator kernels and means: `LinearOperatorKernel` and `LinearOperatorMean`. (`src/AbstractBayesOpt.jl`)

**Surrogate utilities:**

* Moved the `_prep_input` utility functions to standardize input formatting for different types, improving compatibility with operator-based surrogates. (`src/surrogates/surrogates_utils.jl`)

**Exports and test updates:**

* Updated exports in `AbstractBayesOpt.jl` to include new surrogates, operators, and utility functions. (`src/AbstractBayesOpt.jl`),
* Updated `test/runtests.jl` to import the new internal utility and constructor functions for testing. (`test/runtests.jl`)

**TODO before ready for review**
- Working on the test set for 100% coverage
- Write tutorials and documentation related to `LinearOperatorGPs`
- Check equivalence to `StandardGP` and `GradientGP`
- Profiling the functions added